### PR TITLE
Fix TGUI modal popups causing qdel errors

### DIFF
--- a/code/modules/tgui_input/alert.dm
+++ b/code/modules/tgui_input/alert.dm
@@ -72,7 +72,7 @@
 
 /datum/tgui_alert/Destroy(force, ...)
 	SStgui.close_uis(src)
-	QDEL_NULL(buttons)
+	buttons.Cut()
 	return ..()
 
 /**

--- a/code/modules/tgui_input/checkboxes.dm
+++ b/code/modules/tgui_input/checkboxes.dm
@@ -64,7 +64,7 @@
 
 /datum/tgui_checkbox_input/Destroy(force, ...)
 	SStgui.close_uis(src)
-	QDEL_NULL(items)
+	items.Cut()
 	return ..()
 
 /datum/tgui_checkbox_input/proc/wait()

--- a/code/modules/tgui_input/list.dm
+++ b/code/modules/tgui_input/list.dm
@@ -80,7 +80,7 @@
 
 /datum/tgui_list_input/Destroy(force, ...)
 	SStgui.close_uis(src)
-	QDEL_NULL(items)
+	items.Cut()
 	return ..()
 
 /**


### PR DESCRIPTION
`buttons` and `items` are lists of strings, in theory they doesn't need to be cleared at all. in practice, someone might pass an atom reference instead (which will show up as its name), and we should handle that gracefully, so i chose to `Cut()` it instead to prevent harddels caused by that very very unlikely edge case.