### PR TITLE
Replace simulated canyon openspace with exterior

### DIFF
--- a/code/game/turfs/exterior/exterior_surface.dm
+++ b/code/game/turfs/exterior/exterior_surface.dm
@@ -7,8 +7,6 @@
 	possible_states = 13
 	color = "#bdb3c2"
 	dirt_color = "#4c454e"
-	var/datum/map/mapowner = null
-
 	var/day_icon = 'icons/turf/exterior/volcanic.dmi'
 	var/day_icon_state = "0"
 	var/day_states = 0 // possible states
@@ -23,20 +21,18 @@
 	return
 
 /turf/exterior/surface/get_air_graphic()
-	return mapowner.exterior_atmosphere?.graphic
+	return global.using_map.exterior_atmosphere?.graphic
 
 /turf/exterior/surface/Initialize(mapload, no_update_icon)
-	mapowner = global.using_map
-
 	if(possible_states > 0)
 		icon_state = "[rand(0, possible_states)]"
 
-	if(!istype(mapowner))
+	if(!istype(global.using_map))
 		owner = null
 	else
 		//Must be done here, as light data is not fully carried over by ChangeTurf (but overlays are).
-		if(mapowner.planetary_area && istype(loc, world.area))
-			ChangeArea(src, mapowner.planetary_area)
+		if(global.using_map.planetary_area && istype(loc, world.area))
+			ChangeArea(src, locate(global.using_map.planetary_area))
 
 	//. = ..(mapload)	// second param is our own, don't pass to children
 	setup_environmental_lighting()
@@ -64,9 +60,8 @@
 /turf/exterior/surface/setup_environmental_lighting(var/ncolor = COLOR_COLD_SURFACE)
 	if (is_outside())
 		surface_turfs += src
-		if (mapowner)
-			set_ambient_light(ncolor, mapowner.lightlevel)
-			return
+		set_ambient_light(ncolor, global.using_map.lightlevel)
+		return
 	else if (ambient_light)
 		clear_ambient_light()
 
@@ -133,38 +128,34 @@
 	C.set_status(STAT_BLURRY, 5)
 	SET_STATUS_MAX(C, STAT_WEAK, 2)
 	var/temp_adj = 0
-	var/thermal_protection = max(0, C.get_cold_protection(mapowner.exterior_atmosphere.temperature) - 0.5) //This returns a 0 - 1 value, which corresponds to the percentage of protection based on what you're wearing and what you're exposed to.
+	var/thermal_protection = max(0, C.get_cold_protection(global.using_map.exterior_atmosphere.temperature) - 0.5) //This returns a 0 - 1 value, which corresponds to the percentage of protection based on what you're wearing and what you're exposed to.
 	if(thermal_protection < 1)
-		temp_adj = (1-thermal_protection) * ((mapowner.exterior_atmosphere.temperature - C.bodytemperature) / BODYTEMP_COLD_DIVISOR)	//this will be negative
+		temp_adj = (1-thermal_protection) * ((global.using_map.exterior_atmosphere.temperature - C.bodytemperature) / BODYTEMP_COLD_DIVISOR)	//this will be negative
 	C.bodytemperature += between(-100, temp_adj, 500)
 
 /turf/exterior/surface/lake/is_flooded(lying_mob, absolute)
 	. = absolute ? ..() : lying_mob
 
-/turf/simulated/open/exterior
+/turf/exterior/open/canyon
 	name = "canyon"
 	desc = "Looks very deep..."
-	var/datum/map/mapowner = null
 
-/turf/simulated/open/exterior/return_air()
-	return mapowner.exterior_atmosphere
+/turf/exterior/open/canyon/return_air()
+	return global.using_map.exterior_atmosphere
 
-/turf/simulated/open/exterior/Initialize()
-	..()
-	mapowner = global.using_map
+/turf/exterior/open/canyon/Initialize()
+	//Must be done here, as light data is not fully carried over by ChangeTurf (but overlays are).
+	if(global.using_map.planetary_area && istype(loc, world.area))
+		ChangeArea(src, locate(global.using_map.planetary_area))
 	setup_environmental_lighting()
+	. = ..()
 
-/turf/simulated/open/exterior/proc/setup_environmental_lighting(var/ncolor = COLOR_COLD_SURFACE)
+/turf/exterior/open/canyon/setup_environmental_lighting(var/ncolor = COLOR_COLD_SURFACE)
 	if (is_outside())
 		surface_turfs += src
-		if (mapowner)
-			set_ambient_light(ncolor, mapowner.lightlevel)
-			return
+		set_ambient_light(ncolor, global.using_map.lightlevel)
 	else if (ambient_light)
 		clear_ambient_light()
-
-/turf/simulated/open/exterior/proc/switch_cracks()
-	return
 
 /obj/effect/fake_fluid
 	name = "liquid gas"

--- a/code/game/turfs/exterior/exterior_surface.dm
+++ b/code/game/turfs/exterior/exterior_surface.dm
@@ -120,6 +120,8 @@
 	..()
 	if(!ismob(C) && !isitem(C))
 		return
+	if(!simulated)
+		return // don't let ghosts set it off
 	playsound(src, 'sound/chemistry/bufferadd.ogg', 30)
 	new /obj/effect/effect/smoke/bad/evaporation(src)
 	if(!iscarbon(C))

--- a/maps/avalon/avalon.dmm
+++ b/maps/avalon/avalon.dmm
@@ -505,7 +505,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "ayu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -5788,7 +5788,7 @@
 /turf/simulated/floor/tiled/dark/monotile)
 "eNp" = (
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "eOf" = (
 /obj/structure/closet{
@@ -7602,7 +7602,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "gnt" = (
 /turf/simulated/open)
@@ -8793,7 +8793,7 @@
 "hhz" = (
 /obj/structure/ladder,
 /obj/machinery/shelter_hatch/small/closed,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "hhD" = (
 /obj/structure/cable{
@@ -11713,7 +11713,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "jtF" = (
 /obj/structure/railing/mapped{
@@ -12430,7 +12430,7 @@
 /turf/simulated/floor/tiled/white,
 /area/serenity/shelter/medbay/chemistry)
 "jVg" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "jVK" = (
 /obj/effect/floor_decal/corner/purple/border,
@@ -19938,7 +19938,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "pGH" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -21296,7 +21296,7 @@
 "qGm" = (
 /obj/structure/ladder,
 /obj/machinery/shelter_hatch/small,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "qGC" = (
 /obj/structure/cable{
@@ -29252,7 +29252,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "xff" = (
 /obj/structure/closet/firecloset,

--- a/maps/overmap/hillside.dmm
+++ b/maps/overmap/hillside.dmm
@@ -3,14 +3,14 @@
 /turf/exterior/surface,
 /area/space)
 "d" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /turf/exterior/wall/ice,
 /area/space)
 "g" = (
 /turf/simulated/floor/concrete/black/surface,
 /area/space)
 "i" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/space)
 "o" = (
 /turf/simulated/wall/r_wall,
@@ -26,7 +26,7 @@
 /area/space)
 "z" = (
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/space)
 "C" = (
 /obj/effect/floor_decal/industrial/traffic/fulltile,

--- a/maps/overmap/roadsegment.dmm
+++ b/maps/overmap/roadsegment.dmm
@@ -19,7 +19,7 @@
 /area/surface)
 "fB" = (
 /obj/structure/railing/mapped,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "fT" = (
 /obj/effect/overmap_edge{
@@ -74,11 +74,11 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "wj" = (
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "wk" = (
 /obj/effect/floor_decal/industrial/traffic/fulltile,
@@ -125,7 +125,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Gi" = (
 /obj/structure/railing/mapped,
@@ -138,7 +138,7 @@
 	teleport_to_id = "WEHS_west";
 	edge_id = "road_1_east"
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "GN" = (
 /obj/structure/railing/mapped,
@@ -148,13 +148,13 @@
 	teleport_to_id = "WEHS_west";
 	edge_id = "road_1_east"
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Hl" = (
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "HF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -183,7 +183,7 @@
 "Lf" = (
 /obj/structure/railing/mapped,
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Lz" = (
 /turf/simulated/wall/r_wall,
@@ -213,7 +213,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "NW" = (
 /obj/structure/railing/mapped,
@@ -246,15 +246,15 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Tm" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Ut" = (
 /obj/item/mobile_ladder,
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Vi" = (
 /obj/structure/railing/mapped{
@@ -275,7 +275,7 @@
 	dir = 1
 	},
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Xf" = (
 /obj/effect/decal/cleanable/ash,

--- a/maps/overmap_locs/crashed_destiny.dmm
+++ b/maps/overmap_locs/crashed_destiny.dmm
@@ -90,7 +90,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "lo" = (
 /obj/effect/floor_decal/asteroid,
@@ -135,7 +135,7 @@
 /area/surface)
 "so" = (
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "sG" = (
 /obj/random/ammo,
@@ -215,7 +215,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "DQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -333,7 +333,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Qv" = (
 /obj/structure/girder,
@@ -369,7 +369,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Ut" = (
 /obj/abstract/map_data/example{
@@ -378,7 +378,7 @@
 /turf/exterior/surface,
 /area/surface)
 "Uv" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Wb" = (
 /obj/item/stack/material/rods/two,

--- a/maps/overmap_locs/demolished_skyscraper.dmm
+++ b/maps/overmap_locs/demolished_skyscraper.dmm
@@ -194,7 +194,7 @@
 "fC" = (
 /obj/structure/foamedmetal,
 /obj/structure/foamedmetal,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "fI" = (
 /obj/structure/railing/mapped,
@@ -259,7 +259,7 @@
 	dir = 4
 	},
 /obj/structure/ladder,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "hz" = (
 /obj/structure/bed/psych,
@@ -416,7 +416,7 @@
 "kY" = (
 /obj/structure/lattice,
 /obj/structure/window/surface_slag,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "kZ" = (
 /obj/structure/bed/chair/office/comfy/red{
@@ -643,7 +643,7 @@
 /area/surface/location/skyscraper)
 "pO" = (
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "pS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -660,7 +660,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice,
 /obj/structure/window/surface_slag,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "qw" = (
 /obj/item/stack/material/rods,
@@ -677,11 +677,11 @@
 /area/surface/location/skyscraper)
 "qS" = (
 /obj/structure/foamedmetal,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "qV" = (
 /obj/effect/invisible_barrier,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "qZ" = (
 /obj/machinery/light/neon,
@@ -779,7 +779,7 @@
 /turf/simulated/floor/airless,
 /area/surface)
 "tG" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "tP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1372,7 +1372,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Gm" = (
 /obj/structure/table/steel,
@@ -1473,7 +1473,7 @@
 /area/surface/location/skyscraper)
 "IP" = (
 /obj/structure/window/surface_slag,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "IV" = (
 /obj/machinery/door/airlock/lift,
@@ -1879,10 +1879,10 @@
 "Tn" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/mapped,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Ts" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface/location/skyscraper)
 "Tu" = (
 /obj/structure/window/surface_slag,
@@ -1913,7 +1913,7 @@
 /area/surface/location/skyscraper)
 "Ue" = (
 /obj/structure/ladder,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "Ui" = (
 /obj/machinery/light/neon{
@@ -2132,7 +2132,7 @@
 /area/surface/location/skyscraper)
 "Zy" = (
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface/location/skyscraper)
 "Zz" = (
 /obj/effect/decal/cleanable/dirt,

--- a/maps/overmap_locs/space_center.dmm
+++ b/maps/overmap_locs/space_center.dmm
@@ -348,7 +348,7 @@
 "jb" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface/location/space_center)
 "jg" = (
 /obj/structure/bed/chair/office/dark,
@@ -858,7 +858,7 @@
 /area/surface/location/space_center)
 "wY" = (
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface/location/space_center)
 "xb" = (
 /obj/machinery/light/ceiling{
@@ -928,7 +928,7 @@
 "yz" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface/location/space_center)
 "yC" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -1229,7 +1229,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/surface/location/space_center)
 "GC" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface/location/space_center)
 "GK" = (
 /obj/effect/floor_decal/spline/plain/blue,
@@ -1992,7 +1992,7 @@
 /area/surface/location/space_center)
 "YO" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface/location/space_center)
 "YY" = (
 /obj/structure/table/steel,
@@ -2007,7 +2007,7 @@
 /area/surface/location/space_center)
 "Zc" = (
 /obj/structure/railing/mapped,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface/location/space_center)
 "Ze" = (
 /obj/structure/telemetry/server_rack/destroyed,

--- a/maps/serenity/serenity.dmm
+++ b/maps/serenity/serenity.dmm
@@ -1476,7 +1476,7 @@
 /area/serenity/shelter/medbay/floor2/surgery_prep)
 "aLO" = (
 /obj/abstract/landmark/weather_ztag,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "aLQ" = (
 /obj/effect/floor_decal/carpet/green{
@@ -22453,7 +22453,7 @@
 /area/serenity/shelter/admin/annex)
 "kZj" = (
 /obj/structure/railing/mapped,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "kZz" = (
 /obj/machinery/door/blast/regular/open{
@@ -27659,7 +27659,7 @@
 /obj/abstract/map_data/example{
 	height = 15
 	},
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "nGI" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -29223,7 +29223,7 @@
 /turf/simulated/floor/concrete/gray,
 /area/serenity)
 "orh" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "orx" = (
 /obj/structure/flora/bush/sparsegrass,
@@ -37383,7 +37383,7 @@
 /area/serenity/shelter/labs)
 "seV" = (
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "seW" = (
 /obj/structure/cable/blue{
@@ -38951,7 +38951,7 @@
 /turf/simulated/wall/concrete/nano,
 /area/serenity/maintenance/sublevel_one)
 "sTb" = (
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/space)
 "sTi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41875,7 +41875,7 @@
 /area/serenity/shelter/admin/operations_rod)
 "uoA" = (
 /obj/abstract/level_data_spawner/main_level,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "uoD" = (
 /obj/effect/decal/cleanable/cobweb{
@@ -43851,7 +43851,7 @@
 "voU" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
-/turf/simulated/open/exterior,
+/turf/exterior/open/canyon,
 /area/surface)
 "vpf" = (
 /obj/structure/largecrate,


### PR DESCRIPTION
## Description of changes
Canyon turfs were simulated, which resulted in large exterior zones. These zones then kept cacheing `movables()` constantly despite the lack of airflow, which is a waste.
Made some changes to fix stuff I didn't understand about exterior turfs, not sure what the deal with `mapowner` was but it was causing runtimes due to ordering issues when things ran before the turf's Initialize().

Also fixes ghosts setting off condensed lake evaporation by adding a `simulated` check.

I did some brief testing and everything seemed fine, but I'm not sure if there's something I'm overlooking about why it was set up like this.

## Why and what will this PR improve
Prevents large exterior zones which then have to cache movables, wasting lots of CPU.

## Authorship
Me