### PR TITLE
Move connection_edge flow() proc to zones to avoid list overhead

### DIFF
--- a/code/modules/atmospherics/ZAS/Airflow.dm
+++ b/code/modules/atmospherics/ZAS/Airflow.dm
@@ -161,13 +161,17 @@ Contains helper procs for airflow, called by /connection_group.
 	. = ..()
 
 /zone/proc/movables()
-	return movables
-
-/zone/proc/cache_movables()
-	movables.Cut()
-	for(var/turf/simulated/T in contents)
-		for(var/atom/movable/A in T)
+	. = list()
+	for(var/turf/simulated/T as anything in contents) // will never contain non-simulated turfs
+		for(var/atom/movable/A as anything in T) // will never contain non-movables
 			if(!A.simulated || A.anchored)
 				continue
-			movables += A
-	last_movable_calc = world.time
+			. += A
+
+/zone/proc/flow(list/turf/connecting_turfs, differential, repelled)
+	for(var/turf/simulated/target_turf as anything in contents) // these cannot have non-simulated turfs
+		for(var/atom/movable/target_movable as anything in target_turf) // these cannot have non-movable contents
+			if(!target_movable.simulated || target_movable.anchored)
+				continue
+			//If they're already being tossed, don't do it again.
+			target_movable.handle_airflow(differential, connecting_turfs, repelled)

--- a/code/modules/atmospherics/ZAS/ConnectionGroup.dm
+++ b/code/modules/atmospherics/ZAS/ConnectionGroup.dm
@@ -46,11 +46,6 @@ Class Procs:
 	tick()
 		Called every air tick on edges in the processing list. Equalizes gas.
 
-	flow(list/movable, differential, repelled)
-		Airflow proc causing all objects in movable to be checked against a pressure differential.
-		If repelled is true, the objects move away from any turf in connecting_turfs, otherwise they approach.
-		A check against vsc.lightest_airflow_pressure should generally be performed before calling this.
-
 	get_connected_zone(zone/from)
 		Helper proc that allows getting the other zone of an edge given one of them.
 		Only on /connection_edge/zone, otherwise use A.
@@ -94,11 +89,6 @@ Class Procs:
 
 /connection_edge/proc/recheck()
 
-/connection_edge/proc/flow(list/movable, differential, repelled)
-	for(var/atom/movable/M as anything in movable)
-		//If they're already being tossed, don't do it again.
-		M.handle_airflow(differential, connecting_turfs, repelled)
-
 /connection_edge/zone/var/zone/B
 
 /connection_edge/zone/New(zone/A, zone/B)
@@ -136,17 +126,8 @@ Class Procs:
 
 	var/differential = A.air.return_pressure() - B.air.return_pressure()
 	if(abs(differential) >= vsc.airflow_lightest_pressure)
-		var/list/attracted
-		var/list/repelled
-		if(differential > 0)
-			attracted = A.movables()
-			repelled = B.movables()
-		else
-			attracted = B.movables()
-			repelled = A.movables()
-
-		flow(attracted, abs(differential), 0)
-		flow(repelled, abs(differential), 1)
+		A.flow(connecting_turfs, abs(differential), differential < 0)
+		B.flow(connecting_turfs, abs(differential), differential > 0)
 
 	if(equiv)
 		if(direct)
@@ -208,7 +189,7 @@ Class Procs:
 
 	var/differential = A.air.return_pressure() - air.return_pressure()
 	if(abs(differential) >= vsc.airflow_lightest_pressure)
-		flow(A.movables(), abs(differential), differential < 0)
+		A.flow(connecting_turfs, abs(differential), differential < 0)
 
 	if(equiv)
 		A.air.copy_from(air)

--- a/code/modules/atmospherics/ZAS/Zone.dm
+++ b/code/modules/atmospherics/ZAS/Zone.dm
@@ -34,6 +34,11 @@ Class Procs:
 	tick()
 		Called only when the gas content is changed. Archives values and changes gas graphics.
 
+	flow(list/connecting_turfs, differential, repelled)
+		Airflow proc causing all objects in the zone to be checked against a pressure differential.
+		If repelled is true, the objects move away from any turf in connecting_turfs, otherwise they approach.
+		A check against vsc.lightest_airflow_pressure should generally be performed before calling this.
+
 	dbg_data(mob/M)
 		Sends M a printout of important figures for the zone.
 
@@ -52,9 +57,6 @@ Class Procs:
 	var/list/graphic_remove = list()
 	var/last_air_temperature = TCMB
 	var/condensing = TRUE
-
-	var/last_movable_calc = 0 //last world.time of movables indexation
-	var/list/movables = list()
 
 /zone/New()
 	SSair.add_zone(src)
@@ -168,10 +170,6 @@ Class Procs:
 		if(E.sleeping)
 			E.recheck()
 			CHECK_TICK
-
-	// Update movables list
-	if(last_movable_calc + 10 SECONDS < world.time)
-		INVOKE_ASYNC(src, PROC_REF(cache_movables))
 
 	// Handle condensation from the air.
 	if(!condensing && air.total_moles)


### PR DESCRIPTION
## Description of changes
Experimental change. `flow()` has been moved from `connection_edge` onto `zone`, `movables()` is no longer cached, and the `movables()` loop has been inlined in `flow()`.

The logic should be identical, I just inlined `movables()` and passed `connecting_turfs` from `connection_edge`. Seemed to work fine in testing, it had some overtime but notably it was less so than cache_movables.

This may be worth sending upstream to Nebula, along with #213.

## Why and what will this PR improve
 By avoiding passing `movables()` around, we can get a marginal improvement to atmos airflow _without_ the cacheing. This will make active zones more expensive than with the cacheing approach, but inactive zones won't have any movables() cost, so large inactive zones will essentially become free.

## Authorship
Me