### PR TITLE
Fix vehicle interior loading breaking LateInitialize ordering

### DIFF
--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -19,6 +19,8 @@ SUBSYSTEM_DEF(atoms)
 	var/list/created_atoms = list()
 	/// A non-associative list of lists, with the format list(list(atom, list(LateInitialize arguments))).
 	var/list/late_loaders = list()
+	/// A list of mapload markers created during SSatoms init that need to be resolved after all other initialization.
+	var/list/queued_markers = list()
 
 	var/list/BadInitializeCalls = list()
 
@@ -69,6 +71,17 @@ SUBSYSTEM_DEF(atoms)
 			CHECK_TICK
 		report_progress("Late initialized [count] atom\s")
 		late_loaders.Cut()
+
+	// Load any queued map template markers.
+	if(length(queued_markers))
+		// We're sort of stealing SSmapping's job here, but I didn't want to add a 'very late loaders' feature
+		var/list/cached_markers = queued_markers
+		queued_markers = list()
+		for(var/obj/abstract/landmark/map_load_mark/queued_mark as anything in cached_markers)
+			queued_mark.load_subtemplate()
+			if(!QDELETED(queued_mark)) // for if the tile that lands on the landmark is a no-op tile
+				qdel(queued_mark)
+		cached_markers.Cut()
 
 /datum/controller/subsystem/atoms/proc/InitAtom(atom/A, list/arguments)
 	var/the_type = A.type

--- a/code/modules/maps/helper_landmarks.dm
+++ b/code/modules/maps/helper_landmarks.dm
@@ -12,7 +12,8 @@ INITIALIZE_IMMEDIATE(/obj/abstract/landmark/map_load_mark)
 	if(!SSmapping.initialized) // If we're being created prior to SSmapping
 		SSmapping.queued_markers += src // Then run after SSmapping
 	else // created by something during init, like a multitile vehicle
-		init_load_subtemplate()
+		// we have to queue these on SSatoms instead
+		SSatoms.queued_markers += src
 
 /obj/abstract/landmark/map_load_mark/proc/get_subtemplate()
 	if(isnull(map_template_names))


### PR DESCRIPTION
Vehicle interior landmarks, when created by a multitile vehicle object, would immediately load the map during initialization. That caused a bunch of lateloaders to initialize early, which meant decals were running before the turfs they were on.

<img width="331" height="472" alt="image" src="https://github.com/user-attachments/assets/350d8591-4a45-49fc-82aa-effb531d53e2" />

Decals work again! 🎉 