### PR TITLE
Ports DPC and fixes corpse initialization

### DIFF
--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -99,7 +99,9 @@ if(Datum.is_processing) {\
 // TIMER_OVERRIDE is impossible to support because we don't track that for DPC queued calls, and adding a third list for that would be a lot of overhead for no real benefit
 // TIMER_STOPPABLE can't work because it uses timer IDs instead of hashes, and DPC queued calls don't have IDs.
 // TIMER_LOOP doesn't work because it needs to be a timer that can re-insert in the list, and a zero-wait looping timer should really be a ticker subsystem instead.
-// Update this define if any of those change.
+// Update these defines if any of those change.
+/// These are the flags forbidden when putting zero-wait timers on SSdpc instead of SStimer.
+#define DPC_FORBID_FLAGS   TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE | TIMER_LOOP
 /// These are the flags forbidden when putting zero-wait TIMER_UNIQUE timers on SSdpc instead of SStimer.
 #define UDPC_FORBID_FLAGS  TIMER_OVERRIDE | TIMER_STOPPABLE | TIMER_LOOP
 

--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -96,6 +96,13 @@ if(Datum.is_processing) {\
 #define TIMER_NO_HASH_WAIT BITFLAG(4) // For unique timers: don't distinguish timers by wait.
 #define TIMER_LOOP         BITFLAG(5) // Repeat the timer until it's deleted or the parent is destroyed.
 
+// TIMER_OVERRIDE is impossible to support because we don't track that for DPC queued calls, and adding a third list for that would be a lot of overhead for no real benefit
+// TIMER_STOPPABLE can't work because it uses timer IDs instead of hashes, and DPC queued calls don't have IDs.
+// TIMER_LOOP doesn't work because it needs to be a timer that can re-insert in the list, and a zero-wait looping timer should really be a ticker subsystem instead.
+// Update this define if any of those change.
+/// These are the flags forbidden when putting zero-wait TIMER_UNIQUE timers on SSdpc instead of SStimer.
+#define UDPC_FORBID_FLAGS  TIMER_OVERRIDE | TIMER_STOPPABLE | TIMER_LOOP
+
 #define TIMER_ID_NULL -1
 
 /**

--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -8,6 +8,7 @@
 // SS_TICKER
 #define SS_PRIORITY_OVERLAY        100 // Applies overlays. May cause overlay pop-in if it gets behind.
 #define SS_PRIORITY_TIMER          20
+#define SS_PRIORITY_DPC            19
 
 // Normal
 #define SS_PRIORITY_TICKER         100 // Gameticker.

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -64,6 +64,7 @@
 #define RUNLEVEL_SETUP 2
 #define RUNLEVEL_GAME 4
 #define RUNLEVEL_POSTGAME 8
+/// default runlevels for most subsystems
 #define RUNLEVELS_DEFAULT (RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME)
-
-#define RUNLEVELS_ALL (~0)
+/// all valid runlevels - subsystems with this will run all the time after their MC init stage.
+#define RUNLEVELS_ALL (RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME)

--- a/code/controllers/subsystems/DPC.dm
+++ b/code/controllers/subsystems/DPC.dm
@@ -1,0 +1,37 @@
+/*
+This is pretty much just an optimization for wait=0 timers. They're relatively common, but generally don't actually need the more
+ complex features of SStimer. SSdpc can handle these timers instead (and it's a lot simpler than SStimer is), but it can't handle
+ complex timers with flags. This doesn't need to be explicitly used, eligible timers are automatically converted.
+*/
+
+SUBSYSTEM_DEF(dpc)
+	name = "Delayed Procedure Call"
+	wait = 1
+	runlevels = RUNLEVELS_ALL
+	priority = SS_PRIORITY_DPC
+	flags = SS_TICKER | SS_NO_INIT
+
+	var/list/queued_calls = list()
+	var/list/avg = 0
+
+/datum/controller/subsystem/dpc/stat_entry()
+	return ..() + " Q: [queued_calls.len], AQ: ~[round(avg)]"
+
+/datum/controller/subsystem/dpc/fire(resumed = FALSE)
+	var/list/qc = queued_calls
+	if (!resumed)
+		avg = MC_AVERAGE_FAST(avg, qc.len)
+
+	var/q_idex = 1
+
+	while (q_idex <= qc.len)
+		var/datum/callback/CB = qc[q_idex]
+		q_idex += 1
+
+		CB.InvokeAsync()
+
+		if (MC_TICK_CHECK)
+			break
+
+	if (q_idex > 1)
+		queued_calls.Cut(1, q_idex)

--- a/code/controllers/subsystems/DPC.dm
+++ b/code/controllers/subsystems/DPC.dm
@@ -1,7 +1,7 @@
 /*
 This is pretty much just an optimization for wait=0 timers. They're relatively common, but generally don't actually need the more
  complex features of SStimer. SSdpc can handle these timers instead (and it's a lot simpler than SStimer is), but it can't handle
- complex timers with flags. This doesn't need to be explicitly used, eligible timers are automatically converted.
+ timers with certain flags (check MC.dm). This doesn't need to be explicitly used, eligible timers are automatically converted.
 */
 
 SUBSYSTEM_DEF(dpc)
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(dpc)
 	var/unique_avg = 0
 
 /datum/controller/subsystem/dpc/stat_entry()
-	return ..() + " Q: [queued_calls.len], AQ: ~[round(avg)], UQ: [unique_queued_calls.len], AQ: ~[round(unique_avg)]"
+	return ..() + " Q: [queued_calls.len], AQ: ~[round(avg)], UQ: [unique_queued_calls.len], UAQ: ~[round(unique_avg)]"
 
 /datum/controller/subsystem/dpc/fire(resumed = FALSE)
 	var/list/qc = queued_calls

--- a/code/controllers/subsystems/DPC.dm
+++ b/code/controllers/subsystems/DPC.dm
@@ -12,15 +12,19 @@ SUBSYSTEM_DEF(dpc)
 	flags = SS_TICKER | SS_NO_INIT
 
 	var/list/queued_calls = list()
-	var/list/avg = 0
+	var/avg = 0
+	var/list/unique_queued_calls = list()
+	var/unique_avg = 0
 
 /datum/controller/subsystem/dpc/stat_entry()
-	return ..() + " Q: [queued_calls.len], AQ: ~[round(avg)]"
+	return ..() + " Q: [queued_calls.len], AQ: ~[round(avg)], UQ: [unique_queued_calls.len], AQ: ~[round(unique_avg)]"
 
 /datum/controller/subsystem/dpc/fire(resumed = FALSE)
 	var/list/qc = queued_calls
+	var/list/uqc = unique_queued_calls
 	if (!resumed)
 		avg = MC_AVERAGE_FAST(avg, qc.len)
+		unique_avg = MC_AVERAGE_FAST(unique_avg, uqc.len)
 
 	var/q_idex = 1
 
@@ -35,3 +39,17 @@ SUBSYSTEM_DEF(dpc)
 
 	if (q_idex > 1)
 		queued_calls.Cut(1, q_idex)
+
+	q_idex = 1 // Reuse this variable so we don't waste time allocating two
+	while (q_idex <= uqc.len)
+		var/hash = uqc[q_idex]
+		var/datum/callback/CB = uqc[hash]
+		q_idex += 1
+
+		CB.InvokeAsync()
+
+		if (MC_TICK_CHECK)
+			break
+
+	if (q_idex > 1)
+		unique_queued_calls.Cut(1, q_idex)

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -1,7 +1,7 @@
 /// Controls how many buckets should be kept, each representing a tick. (1 minutes worth)
 #define BUCKET_LEN (world.fps*1*60)
 /// Helper for getting the correct bucket for a given timer
-#define BUCKET_POS(timer) (((CEILING((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
+#define BUCKET_POS(timer) (((ceil((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
 #define TIMER_MAX(timer_ss) (timer_ss.head_offset + TICKS2DS(BUCKET_LEN + timer_ss.practical_offset - 1))
 /// Max float with integer precision

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -1,7 +1,7 @@
 /// Controls how many buckets should be kept, each representing a tick. (1 minutes worth)
 #define BUCKET_LEN (world.fps*1*60)
 /// Helper for getting the correct bucket for a given timer
-#define BUCKET_POS(timer) (((round((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
+#define BUCKET_POS(timer) (((CEILING((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
 #define TIMER_MAX(timer_ss) (timer_ss.head_offset + TICKS2DS(BUCKET_LEN + timer_ss.practical_offset - 1))
 /// Max float with integer precision

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -571,7 +571,7 @@ SUBSYSTEM_DEF(timer)
 		PRINT_STACK_TRACE("addtimer called with a callback assigned to a qdeleted object. In the future such timers will not \
 			be supported and may refuse to run or run with a 0 wait")
 
-	if (wait == 0 && !flags)
+	if (wait == 0 && !(flags & DPC_FORBID_FLAGS))
 		SSdpc.queued_calls += callback
 		return
 

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -603,6 +603,22 @@ SUBSYSTEM_DEF(timer)
 					if (hash_timer.flags & TIMER_STOPPABLE)
 						. = hash_timer.id
 					return
+		else
+			if(wait == 0 || flags & TIMER_NO_HASH_WAIT)
+				// Check if a unique DPC queued call exists with the same hash
+				var/datum/callback/dpc_callback = SSdpc.unique_queued_calls[hash]
+				if(dpc_callback)
+					if(flags & TIMER_OVERRIDE)
+						// if this turns out to have too much overhead, could try setting
+						// the hash's callback to null and then just having SSdpc skip nulls?
+						SSdpc.unique_queued_calls -= hash
+					else
+						return // don't create a timer
+			// No timer with this hash exists, so we can use the fast unique-DPC path
+			// Have to make sure it doesn't have illegal flags for unique DPC though
+			if(wait == 0 && !(flags & UDPC_FORBID_FLAGS))
+				SSdpc.unique_queued_calls[hash] = callback
+				return
 	else if(flags & TIMER_OVERRIDE)
 		PRINT_STACK_TRACE("TIMER_OVERRIDE used without TIMER_UNIQUE")
 

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -21,7 +21,7 @@ SUBSYSTEM_DEF(timer)
 	wait = 1 //SS_TICKER subsystem, so wait is in ticks
 	priority = SS_PRIORITY_TIMER
 	flags = SS_NO_INIT | SS_TICKER
-	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+	runlevels = RUNLEVELS_ALL
 
 	/// Queue used for storing timers that do not fit into the current buckets
 	var/list/datum/timedevent/second_queue = list()
@@ -570,6 +570,10 @@ SUBSYSTEM_DEF(timer)
 	if (callback.object != GLOBAL_PROC && QDELETED(callback.object) && !QDESTROYING(callback.object))
 		PRINT_STACK_TRACE("addtimer called with a callback assigned to a qdeleted object. In the future such timers will not \
 			be supported and may refuse to run or run with a 0 wait")
+
+	if (wait == 0 && !flags)
+		SSdpc.queued_calls += callback
+		return
 
 	wait = max(NONUNIT_CEILING(wait, world.tick_lag), world.tick_lag)
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -37,7 +37,7 @@
 	..()
 	if(!species) species = global.using_map.default_species
 	var/species_choice = islist(species) ? pickweight(species) : species
-	new /mob/living/carbon/human/corpse(loc, species_choice, src)
+	new /mob/living/carbon/human/corpse(loc, species_choice, null, src)
 	return INITIALIZE_HINT_QDEL
 
 /obj/abstract/landmark/corpse/proc/randomize_appearance(var/mob/living/carbon/human/M, species_choice)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -67,7 +67,7 @@
 	systemic_oxygen_saturation = 0
 	var/obj/item/organ/internal/heart/heart = GET_INTERNAL_ORGAN(src, BP_HEART)
 	if(heart)
-		heart.pulse = 0
+		heart.pulse = PULSE_NONE
 		heart.damage = heart.max_damage
 
 /mob/living/carbon/human/proc/is_husked()

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -16,9 +16,8 @@
 /mob/living/carbon/human/corpse
 	real_name = "corpse"
 
-/mob/living/carbon/human/corpse/Initialize(mapload, new_species, obj/abstract/landmark/corpse/corpse)
-
-	. = ..(mapload, new_species)
+/mob/living/carbon/human/corpse/Initialize(mapload, var/species_name = null, var/datum/dna/new_dna = null, obj/abstract/landmark/corpse/corpse)
+	. = ..(mapload, species_name, new_dna)
 
 	var/decl/cultural_info/culture = get_cultural_value(TAG_CULTURE)
 	if(culture)
@@ -28,16 +27,16 @@
 			SetName(newname)
 			if(mind)
 				mind.name = real_name
+	if(corpse)
+		corpse.randomize_appearance(src, species_name)
+		corpse.equip_outfit(src)
+	return INITIALIZE_HINT_LATELOAD
 
+/mob/living/carbon/human/corpse/LateInitialize()
+	. = ..()
 	adjustOxyLoss(maxHealth)//cease life functions
 	setBrainLoss(maxHealth)
-	death()
-	var/obj/item/organ/internal/heart/corpse_heart = get_organ(BP_HEART, /obj/item/organ/internal/heart)
-	if(corpse_heart)
-		corpse_heart.pulse = PULSE_NONE//actually stops heart to make worried explorers not care too much
-	if(corpse)
-		corpse.randomize_appearance(src, new_species)
-		corpse.equip_outfit(src)
+	death() // since for some reason they weren't actually getting stat = 2; this also handles stopping their heart
 	update_icon()
 
 /mob/living/carbon/human/dummy/mannequin/add_to_living_mob_list()

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -108,10 +108,11 @@
 	return INITIALIZE_HINT_LATELOAD
 
 // chair may need to init first
+// todo: replace this with a corpse spawner subtype?
 /obj/abstract/landmark/deadcap/LateInitialize()
 	..()
 	var/turf/T = get_turf(src)
-	var/mob/living/carbon/human/corpse = new(T)
+	var/mob/living/carbon/human/corpse = new(T, global.using_map.default_species)
 	scramble(1,corpse,100)
 	corpse.real_name = "Captain"
 	corpse.name = "Captain"

--- a/nuclear_phase.dme
+++ b/nuclear_phase.dme
@@ -219,6 +219,7 @@
 #include "code\controllers\subsystems\configuration.dm"
 #include "code\controllers\subsystems\daycycle.dm"
 #include "code\controllers\subsystems\disposals.dm"
+#include "code\controllers\subsystems\DPC.dm"
 #include "code\controllers\subsystems\evac.dm"
 #include "code\controllers\subsystems\event.dm"
 #include "code\controllers\subsystems\fluids.dm"


### PR DESCRIPTION
Fixes Initialize() for corpses to actually pass the correct species and DNA arguments.
Ports DPC (Delayed Process Call) from upstream in order to hopefully make zero-wait timers less expensive.
This should also fix (some of the) `Bucket pos in past` log spam by making `BUCKET_POS` more correct for ticklags without non-integer reciprocals, e.g. 0.4.